### PR TITLE
Feature/refresh action

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ self-hosted runners by setting the "base_env_prefix" input.
 job-name:
   runs-on: 'ubuntu-latest'
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Builds the package using the standard configuration
     - uses: cascode-labs/build-conda-action/action.yml@v0
 ```
@@ -105,7 +105,7 @@ The following are uploaded to the run as artifacts.
 job-name:
   runs-on: 'ubuntu-latest'
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Initializes Conda on a GitHub hosted Runner
     - uses: conda-incubator/setup-miniconda@v2
       with:

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,11 @@ runs:
         ${{ github.event.repository.name }} \
         ${{ runner.temp }}
       shell: bash -l {0}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.package_artifact_name }}
         path: ${{runner.temp}}/package_outputs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.test_results_artifact_name }}
         path: ${{ github.workspace }}/test_results

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ echo "build_options: ${build_options}"
 echo "action_path: ${action_path}"
 echo "repository_name: ${repository_name}"
 
-echo "::set-output name=PACKAGE_PATH::$(echo "None")"
+echo "PACKAGE_PATH=None" >> "${GITHUB_OUTPUT}"
 
 echo "Checking for the Conda recipe"
 if [ -d "${recipe_path}" ]; then
@@ -87,7 +87,7 @@ read -r -a BUILD_OPTIONS <<< "${build_options}"
 echo "finished setting build options"
 echo "BUILD_OPTIONS: " "${BUILD_OPTIONS[@]}"
 OUT=$(conda build --output "${BUILD_OPTIONS[@]}" "${recipe_path}")
-echo "::set-output name=PACKAGE_PATH::$(echo $OUT)"
+echo "PACKAGE_PATH=$OUT" >> "${GITHUB_OUTPUT}"
 echo ""
 echo "Package output path:"
 echo "  $OUT"


### PR DESCRIPTION
## Description

Hello, it seems that the action was not maintained from some time  and some parts got deprecated or even disabled. When You try to run it today, it will automatically fail because of using `actions/upload-artifact@v2`.
This PR:
- Updates `actions/upload-artifact` to the current version
- Updates `actions/checkout` version in the documentation to also the current one
- Changes the way output is saved, as `::set-output` is deprecated and now it should be saved in `$GITHUB_OUTPUT`

After these changes, the action seems to work fine, but I haven't tested all the possible paths.

## How Has This Been Tested?
Tested by using it in https://github.com/McCzarny/totptray/actions/workflows/conda-build.yml

## Checks:

**Lint Score:**  

**Test Coverage:**

(If a PR worlflow is setup it should report these. Check in the log or the report attached as an artifact)

## Checklist:

- [ ] I linked the issues it addresses
  - a pull request should have 1-3 linked issues
- [ ] I have assigned at least 1 reviewer
- [ ] I have applied appropriate labels
- [ ] I have assigned it to a milestone
- [ ] I have assigned it to a project
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
